### PR TITLE
Rounded rating from trail api

### DIFF
--- a/client/src/pages/FindAHike.js
+++ b/client/src/pages/FindAHike.js
@@ -68,7 +68,7 @@ const FindAHike = () => {
         directions: trail.directions,
         difficulty: trail.difficulty,
         length: trail.length,
-        rating: trail.rating,
+        rating: Math.round(trail.rating),
         url: trail.url,
         img: trail.thumbnail
       }));


### PR DESCRIPTION
rating is a decimal and graphQL doesn't take decimals